### PR TITLE
microformats2 semantic markup and fallback mf1

### DIFF
--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -106,11 +106,11 @@ class Jetpack_Recipes {
 		global $allowedtags;
 		$allowedtags['li'] = array( 'itemprop' => array () );
 
-		$html = '<div class="hrecipe jetpack-recipe" itemscope itemtype="http://schema.org/Recipe">';
+		$html = '<div class="h-recipe hrecipe jetpack-recipe" itemscope itemtype="http://schema.org/Recipe">';
 
 		// Print the recipe title if exists
 		if ( '' !== $atts['title'] ) {
-			$html .= '<h3 class="jetpack-recipe-title" itemprop="name">' . esc_html( $atts['title'] ) . '</h3>';
+			$html .= '<h3 class="p-name fn jetpack-recipe-title" itemprop="name">' . esc_html( $atts['title'] ) . '</h3>';
 		}
 
 		// Print the recipe meta if exists
@@ -119,7 +119,7 @@ class Jetpack_Recipes {
 
 			if ( '' !== $atts['servings'] ) {
 				$html .= sprintf(
-					'<li class="jetpack-recipe-servings" itemprop="recipeYield"><strong>%1$s: </strong>%2$s</li>',
+					'<li class="p-yield yield jetpack-recipe-servings" itemprop="recipeYield"><strong>%1$s: </strong>%2$s</li>',
 					esc_html_x( 'Servings', 'recipe', 'jetpack' ),
 					esc_html( $atts['servings'] )
 				);
@@ -127,7 +127,7 @@ class Jetpack_Recipes {
 
 			if ( '' !== $atts['time'] ) {
 				$html .= sprintf(
-					'<li class="jetpack-recipe-time" itemprop="totalTime"><strong>%1$s: </strong>%2$s</li>',
+					'<li class="dt-duration duration jetpack-recipe-time" itemprop="totalTime"><strong>%1$s: </strong>%2$s</li>',
 					esc_html_x( 'Time', 'recipe', 'jetpack' ),
 					esc_html( $atts['time'] )
 				);
@@ -154,7 +154,7 @@ class Jetpack_Recipes {
 		// Output the image, if we have one.
 		if ( '' !== $atts['image'] ) {
 			$html .= sprintf(
-				'<img class="jetpack-recipe-image" itemprop="thumbnailUrl" src="%1$s" />',
+				'<img class="u-photo photo jetpack-recipe-image" itemprop="thumbnailUrl" src="%1$s" />',
 				esc_url( $atts['image'] )
 			);
 		}
@@ -162,7 +162,7 @@ class Jetpack_Recipes {
 		// Output the description, if we have one.
 		if ( '' !== $atts['description'] ) {
 			$html .= sprintf(
-				'<p class="jetpack-recipe-description">%1$s</p>',
+				'<p class="p-summary summary jetpack-recipe-description">%1$s</p>',
 				esc_html( $atts['description'] )
 			);
 		}
@@ -228,7 +228,7 @@ class Jetpack_Recipes {
 			'title' => esc_html_x( 'Ingredients', 'recipe', 'jetpack' ), //string
 		), $atts, 'recipe-ingredients' );
 
-		$html = '<div class="jetpack-recipe-ingredients">';
+		$html = '<div class="p-ingredient ingredient jetpack-recipe-ingredients">';
 
 		// Print a title unless the user has opted to exclude it.
 		if ( 'false' !== $atts['title'] ) {
@@ -263,12 +263,12 @@ class Jetpack_Recipes {
 
 		switch ( $type ) {
 			case 'directions' :
-				$list_item_replacement = '<li class="jetpack-recipe-directions">${1}</li>';
+				$list_item_replacement = '<li class="e-instructions instructions jetpack-recipe-directions">${1}</li>';
 				$itemprop              = ' itemprop="recipeInstructions"';
 				$listtype              = 'ol';
 				break;
 			case 'ingredients' :
-				$list_item_replacement = '<li class="jetpack-recipe-ingredient">${1}</li>';
+				$list_item_replacement = '<li class="p-ingredient ingredient jetpack-recipe-ingredient">${1}</li>';
 				$itemprop              = ' itemprop="recipeIngredient"';
 				$listtype              = 'ul';
 				break;
@@ -337,7 +337,7 @@ class Jetpack_Recipes {
 				'title' => esc_html_x( 'Directions', 'recipe', 'jetpack' ), //string
 		), $atts, 'recipe-directions' );
 
-		$html = '<div class="jetpack-recipe-directions">';
+		$html = '<div class="e-instructions instructions jetpack-recipe-directions">';
 
 		// Print a title unless the user has specified to exclude it.
 		if ( 'false' !== $atts['title'] ) {


### PR DESCRIPTION
Fixes # .
#### Changes proposed in this Pull Request:

Microformats v1 semantic mark up for hrecipe was already included in the recipe shortcode

I've added microformats2 (http://microformats.org/wiki/h-recipe) semantic mark up for recipes including the following:
h-recipe, p-name, p-ingredient, p-yield, e-instructions, dt-duration, u-photo, p-summary, 

As a fallback for older parsers which don't support mf2, but still have microformats 1 support, I've added the following microformats1 classes:
hrecipe (already existed!), fn, ingredient, yield, instructions, duration, photo, summary

Still missing, but requiring additional code would be "value" & "type" for the ingredients and "timespan" for duration.

Additional missing (suggested) h-recipe (hrecipe) class markup, which would have to occur elsewhere or add additional functionality to the shortcode includes: mf2 (mf1)
p-nutrition (nutrition) adding a shortcode for this in a future version could have a positive effect on public health
p-author (author) - should be handled elsewhere in the theme
dt-published (published) - would need to be supported in the theme or alternately not be shown in output
p-category (tag) - would be need to be supported in the theme for tags & categories

These additions shouldn't cause problems with other functionality, but should provide future benefits as microformats2 becomes more common.

An example recipe with this code can be found at: http://boffosocko.com/2016/07/17/chili-prep-for-dinner-tonight/
#### Testing instructions:
## 

---
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
